### PR TITLE
Add option to use another sendgrid data residency region

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ jobs:
             attachment
 ```
 
+## Use eu region
+
+```yaml
+      - uses: licenseware/send-email-notification@v1
+        with:
+          api-key: ${{ secrets.SENDGRID_API_KEY }}
+          region: eu
+          subject: Test Subject
+          from-email: verified-email@licenseware.io
+          to-email: john-doe@licenseware.io
+          markdown-body: |
+            Mail body
+```
+
 ## Run Docker Container Locally
 
 Grab the latest tag from here:

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,8 @@ inputs:
     required: true
   api-key:
     required: true
+  region:
+    required: false
   subject:
     required: true
   markdown-body:
@@ -27,6 +29,7 @@ runs:
   image: "Dockerfile"
   args:
     - --api-key=${{ inputs.api-key }}
+    - --region=${{ inputs.region }}
     - --from=${{ inputs.from-email }}
     - --to=${{ inputs.to-email }}
     - --subject=${{ inputs.subject }}

--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ parser.add_argument(
     help="Email address to send the notification from",
 )
 parser.add_argument("--api-key", type=str, required=True, help="SendGrid API key")
+parser.add_argument("--region", type=str, required=False, help="SendGrid data residency region", default="global")
 parser.add_argument(
     "--attachments",
     type=str,
@@ -132,6 +133,7 @@ if __name__ == "__main__":
 
     try:
         sg = SendGridAPIClient(args.api_key)
+        sg.set_sendgrid_data_residency(args.region)
         response = sg.send(message)
         print(response.status_code)
         print(response.body)


### PR DESCRIPTION
This pullrequest allow to change the sendgrid data residency region. 

Currently only eu is supported by the sendgrid client, but other regions will be supported as soon as the sendgrid client updates.